### PR TITLE
Improve documentation for testing with mock providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ For a complete set of examples you can review the [full library here](https://gi
 
 <img src="https://aztfmod.azureedge.net/media/standalone.gif" width="720"/> <br/> <br/>
 
+## Testing
+
+For information on testing with mock providers, please refer to the [Testing with Mock Providers](./documentation/testing_with_mock_providers.md) guide.
+
 ## Community
 
 Feel free to open an issue for feature or bug, or to submit a PR, [Please check out the WIKI for coding standards, common patterns and PR checklist.](https://github.com/aztfmod/terraform-azurerm-caf/wiki)

--- a/documentation/testing_with_mock_providers.md
+++ b/documentation/testing_with_mock_providers.md
@@ -1,0 +1,153 @@
+# Testing with Mock Providers in CAF Terraform Module
+
+This document provides guidance on how to use mock providers for testing the Cloud Adoption Framework for Azure Terraform module.
+
+## Introduction
+
+Mock providers allow you to test your Terraform configurations without making actual API calls to Azure. This is useful for:
+- Faster testing as no real resources are created
+- Testing without Azure credentials
+- Validating configuration syntax and logic
+- CI/CD pipelines where real resource creation is not desired
+
+## Mock Provider Structure
+
+The CAF module uses Terraform's built-in testing framework with mock providers. The test files are located in the `examples/tests` directory:
+
+- `examples/tests/general.tftest.hcl`: Basic test configuration with mock providers
+- `examples/tests/mock/e2e_plan.tftest.hcl`: End-to-end plan test configuration
+- `examples/tests/mock_data/data.tfmock.hcl`: Mock data definitions
+
+## Creating Mock Data
+
+Mock data is defined in `.tfmock.hcl` files. The CAF module includes a base mock data file at `examples/tests/mock_data/data.tfmock.hcl` that provides mock responses for common data sources:
+
+```hcl
+mock_data "azurerm_client_config" {
+  defaults = {
+    client_id       = "00000000-0000-0000-0000-000000000000"
+    object_id       = "00000000-0000-0000-0000-000000000000"
+    subscription_id = "00000000-0000-0000-0000-000000000000"
+    tenant_id       = "00000000-0000-0000-0000-000000000000"
+  }
+}
+```
+
+You can extend this file or create new ones for specific test scenarios. The mock data should include all the necessary attributes that your Terraform configuration expects to receive from the provider.
+
+## Configuring Mock Providers
+
+Mock providers are configured in `.tftest.hcl` files. There are two approaches:
+
+1. Basic configuration (no source specified):
+```hcl
+mock_provider "azurerm" {
+}
+```
+
+2. Configuration with a source directory:
+```hcl
+mock_provider "azurerm" {
+  source = "./tests/mock_data"
+}
+```
+
+When a source is specified, Terraform will look for `.tfmock.hcl` files in that directory. This allows you to provide custom mock responses for data sources and resources.
+
+For providers with aliases, you can specify the alias in the mock provider configuration:
+
+```hcl
+mock_provider "azurerm" {
+  alias  = "vhub"
+  source = "./tests/mock_data"
+}
+```
+
+## Running Tests with Mock Providers
+
+To run tests with mock providers, use the `terraform test` command from the examples directory:
+
+```bash
+terraform -chdir=./examples test \
+-test-directory=./tests/mock \
+-var-file=../examples/path/to/your/configuration.tfvars \
+-verbose
+```
+
+This command:
+1. Changes to the examples directory
+2. Runs tests from the specified test directory
+3. Uses the specified var file for configuration
+4. Provides verbose output
+
+The test command will execute the test cases defined in the `.tftest.hcl` files in the specified test directory. Each test case can include commands like `plan`, `apply`, and assertions to validate the expected behavior of your Terraform configuration.
+
+## Testing Different Components
+
+Each subfolder in the `/examples` directory represents a different test case. To test a specific component:
+
+1. Identify the example configuration in the appropriate subfolder
+2. Run the test command with the corresponding var file
+
+For example, to test communication services:
+
+```bash
+terraform -chdir=./examples test \
+-test-directory=./tests/mock \
+-var-file=../examples/communication/communication_services/101-communication_service/configuration.tfvars \
+-verbose
+```
+
+This will run the tests defined in the `.tftest.hcl` files in the `examples/tests/mock` directory using the configuration from the specified var file.
+
+## Creating Custom Test Cases
+
+You can create custom test cases by defining new `.tftest.hcl` files in the `examples/tests/mock` directory. A basic test case might look like:
+
+```hcl
+mock_provider "azurerm" {
+  source = "./tests/mock_data"
+}
+
+mock_provider "azuread" {
+  source = "./tests/mock_data"
+}
+
+run "test_plan" {
+  command = plan
+  
+  assert {
+    condition     = length(local.resource_groups) > 0
+    error_message = "No resource groups defined"
+  }
+}
+```
+
+This test case will run a plan and assert that there is at least one resource group defined in the configuration.
+
+## Best Practices
+
+1. Always use mock providers for testing instead of connecting to Azure
+2. Create specific mock data for your test scenarios
+3. Test all examples before submitting changes
+4. Organize tests by component in the examples directory
+5. Use the verbose flag to get detailed output
+6. Include assertions in your test cases to validate expected behavior
+7. Test both successful and error scenarios
+8. Keep mock data up-to-date with the latest provider schema
+
+## Troubleshooting
+
+If you encounter issues when running tests with mock providers, consider the following:
+
+1. Ensure that the mock data includes all the necessary attributes for your configuration
+2. Check that the path to the mock data directory is correct
+3. Verify that the var file path is correct
+4. Use the verbose flag to get more detailed output
+5. Check for syntax errors in your `.tftest.hcl` and `.tfmock.hcl` files
+
+## Conclusion
+
+Using mock providers for testing is an essential practice for developing and maintaining Terraform configurations. It allows you to validate your configurations without creating real resources, making the testing process faster, safer, and more reliable.
+
+By following the guidelines in this document, you can effectively test your Terraform configurations using mock providers in the CAF module.

--- a/examples/tests/README.md
+++ b/examples/tests/README.md
@@ -2,6 +2,8 @@
 
 This README provides an example on how to use locally Terraform test commands.
 
+For comprehensive documentation on testing with mock providers, please refer to the [Testing with Mock Providers](../../documentation/testing_with_mock_providers.md) guide.
+
 ## Running Tests
 
 To run tests in Terraform, you can use the following command:


### PR DESCRIPTION
This pull request introduces documentation for testing with mock providers in the Cloud Adoption Framework (CAF) for Azure Terraform module. The changes include updates to the `README.md` file, a new detailed guide on testing with mock providers, and a reference update in the `examples/tests/README.md` file.

Documentation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R30-R33): Added a section on testing with mock providers and a link to the new guide.
* [`documentation/testing_with_mock_providers.md`](diffhunk://#diff-aa0467d634d33d67f56221458f972f07d20cae992ffc6bb426125b70a8167c1cR1-R153): Created a comprehensive guide on how to use mock providers for testing Terraform configurations, including sections on mock provider structure, creating mock data, configuring mock providers, running tests, and best practices.
* [`examples/tests/README.md`](diffhunk://#diff-a5d91aa6c2aa6931ef6b06b0cbfb6723cc257005c0667a122f9533d77a684a6aR5-R6): Added a reference to the new guide for comprehensive documentation on testing with mock providers.